### PR TITLE
🔀 :: (#36) -repositoryimpl usecase 추가

### DIFF
--- a/data/src/main/java/remote/datasource/Gauthdatasource.kt
+++ b/data/src/main/java/remote/datasource/Gauthdatasource.kt
@@ -9,5 +9,5 @@ interface Gauthdatasource {
 
     fun gauthLogout(): Flow<Unit>
 
-    fun gauthaccess(refreshToken: String): Flow<Gauthloginresponse>
+    suspend fun gauthaccess(refreshToken: String): Flow<Gauthloginresponse>
 }

--- a/data/src/main/java/remote/datasource/Gauthdatasourceimpl.kt
+++ b/data/src/main/java/remote/datasource/Gauthdatasourceimpl.kt
@@ -16,6 +16,6 @@ class Gauthdatasourceimpl @Inject constructor(
     override  fun gauthliogin(body: GauthloginRequestBody): Flow<Gauthloginresponse> =
         performApiRequest { authService.gauthilogin(body=body) }
 
-    override fun gauthaccess(refreshToken: String): Flow<Gauthloginresponse> =
+    override suspend fun gauthaccess(refreshToken: String): Flow<Gauthloginresponse> =
         performApiRequest { authService.gauthAccess(refreshToken=refreshToken) }
 }

--- a/data/src/main/java/repoistory/Authrepoistoryimpl.kt
+++ b/data/src/main/java/repoistory/Authrepoistoryimpl.kt
@@ -3,20 +3,25 @@ package repoistory
 import Model.auth.request.GauthloginRequestBodyModel
 import Model.auth.response.GauthloginresponseModel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import remote.datasource.Gauthdatasource
+import remote.dto.auth.request.toDto
+import remote.dto.auth.response.toLogin
 import reopoistory.Authrepoistory
 import javax.inject.Inject
 
 class Authrepoistoryimpl @Inject constructor(
+    private val gauthdatasource: Gauthdatasource
 ) : Authrepoistory {
     override fun GauthLogout(): Flow<Unit> {
-        TODO("Not yet implemented")
+       return gauthdatasource.gauthLogout()
     }
 
-    override  fun GAuthAccess(refreshToken: String): Flow<GauthloginresponseModel> {
-        TODO("Not yet implemented")
+    override suspend fun GAuthAccess(refreshToken: String): Flow<GauthloginresponseModel> {
+      return gauthdatasource.gauthaccess(refreshToken = refreshToken).map { it.toLogin()  }
     }
 
     override  fun GAuthLogin(body: GauthloginRequestBodyModel): Flow<GauthloginresponseModel> {
-        TODO("Not yet implemented")
+        return gauthdatasource.gauthliogin(body = body.toDto()).map { it.toLogin() }
     }
 }

--- a/domain/src/main/java/Usecase/auth/GAuthLoginUseCase.kt
+++ b/domain/src/main/java/Usecase/auth/GAuthLoginUseCase.kt
@@ -1,0 +1,14 @@
+package Usecase.auth
+
+import Model.auth.request.GauthloginRequestBodyModel
+import reopoistory.Authrepoistory
+import javax.inject.Inject
+
+class GAuthLoginUseCase @Inject constructor(
+    private val authrepoistory: Authrepoistory
+) {
+     operator fun invoke(body: GauthloginRequestBodyModel) = runCatching {
+        authrepoistory.GAuthLogin(body = body)
+
+    }
+}

--- a/domain/src/main/java/Usecase/auth/LogoutUseCase.kt
+++ b/domain/src/main/java/Usecase/auth/LogoutUseCase.kt
@@ -1,0 +1,13 @@
+package Usecase.auth
+
+import reopoistory.Authrepoistory
+import javax.inject.Inject
+
+class LogoutUseCase @Inject constructor(
+    private val authrepoistory: Authrepoistory
+) {
+    operator fun  invoke()=runCatching{
+        authrepoistory.GauthLogout()
+
+    }
+}

--- a/domain/src/main/java/Usecase/auth/TokenRefreshUsecase.kt
+++ b/domain/src/main/java/Usecase/auth/TokenRefreshUsecase.kt
@@ -1,0 +1,14 @@
+package Usecase.auth
+
+import Model.auth.response.GauthloginresponseModel
+import kotlinx.coroutines.flow.Flow
+import reopoistory.Authrepoistory
+import javax.inject.Inject
+
+class TokenRefreshUsecase @Inject constructor(
+    private val authrepoistory: Authrepoistory
+) {
+
+   operator suspend fun invoke(refreshToken: String): Flow<GauthloginresponseModel> =
+       authrepoistory.GAuthAccess(refreshToken=refreshToken)
+}

--- a/domain/src/main/java/reopoistory/Authrepoistory.kt
+++ b/domain/src/main/java/reopoistory/Authrepoistory.kt
@@ -8,8 +8,9 @@ interface Authrepoistory {
 
      fun GAuthLogin(body: GauthloginRequestBodyModel): Flow<GauthloginresponseModel>
 
-     fun GAuthAccess(refreshToken: String): Flow<GauthloginresponseModel>
+     suspend fun GAuthAccess(refreshToken: String): Flow<GauthloginresponseModel>
 
      fun GauthLogout(): Flow<Unit>
+
 
 }


### PR DESCRIPTION
## 💡 개요

auth 부분에 repositoryimpl 기능 구현 usecase 구현이 필요했습니다.

## 📃 작업내용

auth 부분에 repositoryimpl 기능 구현 usecase 구현 했습니다

## 🔀 변경사항
add repositoryimpl
add LogoutUseCase
add TokenRefreshUsecase
add GAuthLoginUseCase

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
	- Google 인증 로그인 요청을 처리하는 `GAuthLoginUseCase` 클래스 추가.
	- 로그아웃 기능을 처리하는 `LogoutUseCase` 클래스 추가.
	- 토큰 갱신 기능을 처리하는 `TokenRefreshUsecase` 클래스 추가.
- **변경 사항**
	- `gauthaccess` 메서드가 일반 함수에서 suspend 함수로 변경되어 비동기 호출 가능.
	- 인증 저장소의 `GAuthAccess` 및 `GAuthLogin` 메서드 구현 변경.
	- `GauthLogout` 메서드에 실제 기능 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->