### PR TITLE
:38 :: AuthViewmodel 에 onFailure 블록에서 가독성을 위해 변수명 it을 expection으로 변경

### DIFF
--- a/presentation/src/main/java/viewModel/login/AuthViewModel.kt
+++ b/presentation/src/main/java/viewModel/login/AuthViewModel.kt
@@ -25,7 +25,7 @@ class AuthViewModel @Inject constructor(
 
     private val _saveTokenUiState = MutableStateFlow<SaveTokenUiState>(SaveTokenUiState.Loading)
     internal val saveTokenUiState = _saveTokenUiState.asStateFlow()
-    fun gAuthLogin(
+    internal fun gAuthLogin(
         code: String,
     ) = viewModelScope.launch {
         _loginUiState.value = LoginUiState.Loading
@@ -38,7 +38,8 @@ class AuthViewModel @Inject constructor(
                     )
                 }
             }.onFailure {
-                _loginUiState.value = LoginUiState.Error(it)
+                    exception ->
+                _loginUiState.value = LoginUiState.Error(exception)
             }
     }
 
@@ -48,9 +49,9 @@ class AuthViewModel @Inject constructor(
         _saveTokenUiState.value = SaveTokenUiState.Loading
         saveTokenUseCase(data = data)
             .onSuccess {
-            _saveTokenUiState.value = SaveTokenUiState.Success
-        }.onFailure {
-                _saveTokenUiState.value = SaveTokenUiState.Error(it)
+                _saveTokenUiState.value = SaveTokenUiState.Success
+            }.onFailure { exception ->
+                _saveTokenUiState.value = SaveTokenUiState.Error(exception)
             }
     }
 


### PR DESCRIPTION


## 💡 개요
 AuthViewmodel 에 onFailure 블록에서 가독성을 위해 변수명 it을 expection으로 변경

## 📃 작업내용
 AuthViewmodel 에 onFailure 블록에서 가독성을 위해 변수명 it을 expection으로 변경

## 🔀 변경사항
 AuthViewmodel 에 onFailure 블록에서 가독성을 위해 변수명 it을 expection으로 변경

## 🙋‍♂️ 질문사항
- 개선할 점, 오타, 코드에 이산한 부분이 있다면 Comment 달아주세요.
## 🍴 사용방법

## 🎸 기타


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **개선 사항**
	- Google 인증 로그인 함수의 가시성 수정
	- 오류 처리 로직 개선
	- 코드 가독성 향상을 위한 예외 처리 방식 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->